### PR TITLE
dont allow login/signup page if already logged in

### DIFF
--- a/pages/loggedin.html
+++ b/pages/loggedin.html
@@ -13,10 +13,10 @@
     <script src="https://cdn.jsdelivr.net/npm/bs-custom-file-input/dist/bs-custom-file-input.js"></script>
   </head>
   <body class="d-flex flex-column vh-100">
-    <h1 class="display-5">please sign in</h1>
+    <h1 class="display-5">you are logged in?</h1>
     <br />
     <a href="/signup">sign up</a>
     <a href="/login">sign in</a>
-    homepage?
+    you are already logged in?
   </body>
 </html>

--- a/pages/login.html
+++ b/pages/login.html
@@ -13,7 +13,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bs-custom-file-input/dist/bs-custom-file-input.js"></script>
   </head>
   <body class="d-flex flex-column vh-100">
-    <h1 class="display-5">sign up</h1>
+    <h1 class="display-5">log in please</h1>
     <br />
     <form action="/login" class="validated-form" method="POST" novalidate>
       <div class="mb-3">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1a2c81179da3d182f171f392f9582706aa9942aa  | 
|--------|--------|

### Summary:
This PR prevents logged-in users from accessing login/signup pages by redirecting them and introduces a new page for logged-in status.

**Key points**:
- Redirect logged-in users away from login/signup pages.
- Introduce `loggedin.html` to inform users they are already logged in.
- Update text in `index.html` and `login.html`.
- Modify `server.ts` to check authentication status before serving pages.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->